### PR TITLE
Output OpenSSL error message only in debug build

### DIFF
--- a/libcdoc/Crypto.cpp
+++ b/libcdoc/Crypto.cpp
@@ -413,6 +413,7 @@ Crypto::fromECPublicKeyDer(const std::vector<uint8_t> &der, int curveName)
 		return std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)>(nullptr, EVP_PKEY_free);
 	const uint8_t *p = der.data();
 	EVP_PKEY *key = d2i_PublicKey(EVP_PKEY_EC, &params, &p, long(der.size()));
+#ifndef NDEBUG
     if (!key)
     {
         unsigned long errorCode = ERR_get_error();
@@ -420,6 +421,7 @@ Crypto::fromECPublicKeyDer(const std::vector<uint8_t> &der, int curveName)
         ERR_error_string_n(errorCode, errorMsg, 256);
         std::cerr << errorMsg << std::endl;
     }
+#endif
 	return std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)>(key, EVP_PKEY_free);
 }
 


### PR DESCRIPTION
Outputs error message in Crypto::fromECPublicKeyDer only if it is a debug build.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Firstname Lastname <firstname.lastname@example.com>
