### PR TITLE
Handling of decrypt parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(POLICY CMP0167)
     cmake_policy(SET CMP0167 NEW)
 endif()
 
-project(libcdoc VERSION 0.1.1)
+project(libcdoc VERSION 0.1.2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 

--- a/libcdoc/cdoc-tool.cpp
+++ b/libcdoc/cdoc-tool.cpp
@@ -10,16 +10,10 @@
 using namespace std;
 using namespace libcdoc;
 
-//
-//
-//
-//
 
-
-static void
-print_usage(ostream& ofs)
+static void print_usage(ostream& ofs)
 {
-    ofs << "cdoc-tool encrypt [--library PKCS11LIBRARY] --rcpt RECIPIENT [--rcpt...] -v1 --out OUTPUTFILE FILE [FILE...]" << endl;
+    ofs << "cdoc-tool encrypt [--library PKCS11LIBRARY] --rcpt RECIPIENT [--rcpt...] [-v1] --out OUTPUTFILE FILE [FILE...]" << endl;
     ofs << "  Encrypt files for one or more recipients" << endl;
     ofs << "  RECIPIENT has to be one of the following:" << endl;
     ofs << "    label:cert:CERTIFICATE_HEX - public key from certificate" << endl;
@@ -29,19 +23,21 @@ print_usage(ostream& ofs)
     ofs << "    label:pw:PASSWORD - Derive key using PWBKDF" << endl;
     ofs << "    label:p11sk:SLOT:[PIN]:[PKCS11 ID]:[PKCS11 LABEL] - use AES key from PKCS11 module" << endl;
     ofs << "    label:p11pk:SLOT:[PIN]:[PKCS11 ID]:[PKCS11 LABEL] - use public key from PKCS11 module" << endl;
-    ofs << "  -v1 creates CDOC1 version container. Supported only on encryption with certificate." << endl;
-    ofs << "  --server ID SEND_URL Specify a keyserver. The recipient key will be stored in server instead of in the document." << endl;
+    ofs << "  -v1 - creates CDOC1 version container. Supported only on encryption with certificate." << endl;
+    ofs << "  --server ID SEND_URL - specifies a keyserver. The recipient key will be stored in server instead of in the document." << endl;
     ofs << endl;
     ofs << "cdoc-tool decrypt [--library LIBRARY] ARGUMENTS FILE [OUTPU_DIR]" << endl;
     ofs << "  Decrypt container using lock specified by label" << endl;
     ofs << "  Supported arguments" << endl;
-    ofs << "    --label LABEL   CDoc container lock label" << endl;
-    ofs << "    --slot SLOT     PKCS11 slot number" << endl;
-    ofs << "    --secret|password|pin SECRET    Secret phrase (either lock password or PKCS11 pin)" << endl;
-    ofs << "    --key-id        PKCS11 key id" << endl;
-    ofs << "    --key-label     PKCS11 key label" << endl;
-    ofs << "    --library       path to the PKCS11 library to be used" << endl;
-    ofs << "    --server ID FETCH_URL Specify a keyserver. The recipient key will be loaded from server." << endl;
+    ofs << "    --label LABEL - CDOC container's lock label" << endl;
+    ofs << "    --slot SLOT - PKCS11 slot number" << endl;
+    ofs << "    --password PASSWORD - lock's password" << endl;
+    ofs << "    --secret SECRET - secret phrase (AES key)" << endl;
+    ofs << "    --pin PIN - PKCS11 pin" << endl;
+    ofs << "    --key-id - PKCS11 key ID" << endl;
+    ofs << "    --key-label - PKCS11 key label" << endl;
+    ofs << "    --library - path to the PKCS11 library to be used" << endl;
+    ofs << "    --server ID FETCH_URL - specifies a keyserver. The recipient key will be loaded from the server." << endl;
     ofs << endl;
     ofs << "cdoc-tool locks FILE" << endl;
     ofs << "  Show locks in a container file" << endl;
@@ -162,7 +158,6 @@ static int ParseAndEncrypt(int argc, char *argv[])
 #endif
             } else {
                 cerr << "Unkown method: " << method << endl;
-                // print_usage(cerr);
                 return 1;
             }
             i += 1;
@@ -260,15 +255,18 @@ static int ParseAndDecrypt(int argc, char *argv[])
             }
             label = argv[i + 1];
             i += 1;
-        } else if (!strcmp(argv[i], "--password") || !strcmp(argv[i], "--secret") || !strcmp(argv[i], "--pin")) {
+        } else if (!strcmp(argv[i], "--password") || !strcmp(argv[i], "--pin")) {
             if ((i + 1) >= argc) {
                 return 1;
             }
             string_view s(argv[i + 1]);
-            if (s.starts_with("0x"))
-                secret = fromHex(s.substr(2));
-            else
-                secret.assign(s.cbegin(), s.cend());
+            secret.assign(s.cbegin(), s.cend());
+            i += 1;
+        } else if (!strcmp(argv[i], "--secret")) {
+            if (i + 1 >= argc) {
+                return 1;
+            }
+            secret = fromHex(argv[i + 1]);
             i += 1;
         } else if (!strcmp(argv[i], "--slot")) {
             if ((i + 1) >= argc) {


### PR DESCRIPTION
Treats the value followed to --secret argument as a hexadecimal-string while the value followed to --password or --pin argument is treated as regular string.

Signed-off-by: Erkki Arus <erkki@raulwalter.com>
