### PR TITLE
Keep LogLevelTrace in release build

### DIFF
--- a/cdoc/ILogger.h
+++ b/cdoc/ILogger.h
@@ -64,12 +64,10 @@ enum LogLevel
      */
     LogLevelDebug,
 
-#ifndef NDEBUG
     /**
-     * @brief Most verbose level. Used for development and seldom enabled in production.
+     * @brief Most verbose level. Used for development, NOP in production code.
      */
     LogLevelTrace
-#endif
 };
 
 


### PR DESCRIPTION
Keep LogLevelTrace enum on release build even if trace-level logging is removed. Thus Digidoc client can simply set min level to trace and sort things out in it's own configuration.

Signed-off-by: Lauris Kaplinski <lauris@raulwalter.com>
