### PR TITLE
Made PKCS11Backend connectToKey overridable in Java

### DIFF
--- a/cdoc/PKCS11Backend.h
+++ b/cdoc/PKCS11Backend.h
@@ -133,7 +133,7 @@ struct CDOC_EXPORT PKCS11Backend : public CryptoBackend {
      * @param priv whether to connect to private or secret key
      * @return error code or OK
      */
-    virtual result_t connectToKey(int idx, bool priv) = 0;
+    virtual result_t connectToKey(int idx, bool priv) { return NOT_IMPLEMENTED; };
     /**
      * @brief whether to use PSS RSA padding
      *


### PR DESCRIPTION
Default implementation returns NOT_IMPLEMENTED, swig does not make pure virtual methods overridable

Signed-off-by: Lauris Kaplinski <lauris.kaplinski@raulwalter.com>
