### PR TITLE
Fix building in Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Prepare vcpkg
       uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: e4644bd15436d406bba71928d086c809e5c9ca45
+        vcpkgGitCommitId: 5ee5eee0d3e9c6098b24d263e9099edcdcef6631
         vcpkgJsonGlob: ./vcpkg.json
         runVcpkgInstall: true
       env:
@@ -101,7 +101,7 @@ jobs:
       if: matrix.target != 'macos'
       uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: e4644bd15436d406bba71928d086c809e5c9ca45
+        vcpkgGitCommitId: 5ee5eee0d3e9c6098b24d263e9099edcdcef6631
         vcpkgJsonGlob: ./vcpkg.json
         runVcpkgInstall: true
       env:
@@ -137,7 +137,7 @@ jobs:
     - name: Prepare vcpkg
       uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: e4644bd15436d406bba71928d086c809e5c9ca45
+        vcpkgGitCommitId: 5ee5eee0d3e9c6098b24d263e9099edcdcef6631
         vcpkgJsonGlob: ./vcpkg.json
         runVcpkgInstall: true
         runVcpkgFormatString: "[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`, `--x-feature`, `tests`]"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ cmake_install.cmake
 debian/tmp/
 debian/source/
 obj-x86_64-linux-gnu/
+test/data/tmp/
+vcpkg/
+vcpkg_installed/

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For more information refer [doc/intro.md](doc/intro.md) document.
 ### Windows
 
 1. Install dependencies and necessary tools from
-	* [Visual Studio Community 2019/2022](https://www.visualstudio.com/downloads/)
+	* [Visual Studio Community 2022](https://www.visualstudio.com/downloads/)
 	* [CMake](http://www.cmake.org)
 	* [vcpkg](https://vcpkg.io/)
 	* [Swig](http://swig.org/download.html) - Optional, for C#, Python and Java bindings
@@ -108,14 +108,6 @@ For more information refer [doc/intro.md](doc/intro.md) document.
         git clone https://github.com/open-eid/libcdoc.git
         cd libcdoc
 
-4. Configure
+4. Configure and Build
 
-        cmake --toolchain vcpkg/scripts/buildsystems/vcpkg.cmake `
-              -DVCPKG_TARGET_TRIPLET=x64-windows `
-              -DVCPKG_MANIFEST_FEATURES=tests `
-              -B build -S .
-
-    
-5. Build
-
-        cmake --build build
+        .\build.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,50 @@
+#powershell -ExecutionPolicy ByPass -File build.ps1
+param(
+  [string]$libcdoc = $PSScriptRoot,
+  [string]$platform = "x64",
+  [string]$build_number = $(if ($null -eq $env:BUILD_NUMBER) {"0"} else {$env:BUILD_NUMBER}),
+  [string]$git = "git.exe",
+  [string]$vcpkg = "vcpkg\vcpkg.exe",
+  [string]$vcpkg_dir = (split-path -parent $vcpkg),
+  [string]$vcpkg_installed = $libcdoc,
+  [string]$vcpkg_triplet = "x64-windows",
+  [string]$vcpkg_installed_platform = "$vcpkg_installed\vcpkg_installed",
+  [string]$cmake = "cmake.exe",
+  [string]$generator = "Visual Studio 17 2022",
+  [switch]$RunTests = $false,
+)
+
+if(!(Test-Path -Path $vcpkg)) {
+  & $git clone https://github.com/microsoft/vcpkg.git $vcpkg_dir
+  & $vcpkg_dir\bootstrap-vcpkg.bat
+}
+
+$cmakeext = @()
+if($platform -eq "arm64" -and $env:VSCMD_ARG_HOST_ARCH -ne "arm64") {
+  $cmakeext += "-DCMAKE_DISABLE_FIND_PACKAGE_Python3=yes"
+  $RunTests = $false
+}
+if($RunTests) {
+  $cmakeext += "-DVCPKG_MANIFEST_FEATURES=tests"
+}
+
+$buildpath = "build"
+
+& $cmake --fresh -B $buildpath -S . "-G$generator" $cmakeext `
+    "--toolchain $vcpkg_dir/scripts/buildsystems/vcpkg.cmake" `
+    "-DVCPKG_INSTALLED_DIR=$vcpkg_installed_platform" `
+    "-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet"
+
+foreach($type in @("Debug", "RelWithDebInfo")) {
+    "==================="
+    "Build Configuration: " + $type
+    "==================="
+    & $cmake --build $buildpath --config $type
+#    & $cmake --install $buildpath
+}
+
+if($RunTests) {
+    Push-Location "$libcdoc\$buildpath"
+    ctest -V -C Debug
+    Pop-Location
+}

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -410,7 +410,7 @@ Following options are supported:
 - `--pin PIN` - PKCS11 (smart-card's) pin code.
 - `--key-id` - PKCS11 key ID.
 - `--key-label` - PKCS11 key label.
-- `--library PKCS11_LIBRARY` - path to the PKCS11 library. Same as in encryption case.
+- `--library PKCS11_LIBRARY` - path to the PKCS11 library. Same as in encryption case.
 - `--server ID URL(s)` - specifies a key or share server. Same as in encryption case.
 - `--accept SERVER_CERT_FILENAME` - path to server's TLS certificate file. Same as in encryption case.
 - `FILE` - encrypted file to be decrypted.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,7 +21,7 @@
   "features": {
     "tests": { "description": "Build tests", "dependencies": ["boost-test"] }
   },
-  "builtin-baseline": "e4644bd15436d406bba71928d086c809e5c9ca45",
+  "builtin-baseline": "5ee5eee0d3e9c6098b24d263e9099edcdcef6631",
   "vcpkg-configuration": {
     "overlay-triplets": ["./vcpkg-triplets"]
   }


### PR DESCRIPTION
* Fixed building on MS Windows platform together with vcpkg packages restoring;
* Added build.ps1 PowerShell script to simplify building in Windows;
* Updated README.md file regarding to building in Windows;
* Updated doc/usage.md file by removing one <SYN> symbol.

Signed-off-by: Erkki Arus <erkki@raulwalter.com>
