### PR TITLE
Fixed Mobile ID signing

### DIFF
--- a/cdoc/CDoc2Reader.cpp
+++ b/cdoc/CDoc2Reader.cpp
@@ -246,7 +246,9 @@ CDoc2Reader::getFMK(std::vector<uint8_t>& fmk, unsigned int lock_idx)
 		std::vector<std::string> tickets;
 		std::vector<uint8_t> cert;
 		result_t result = NOT_IMPLEMENTED;
-		if (conf->getValue(Configuration::SHARE_SIGNER) == "SMART_ID") {
+		std::string signer = conf->getValue(Configuration::SHARE_SIGNER);
+		LOG_DBG("Signer: {}", signer);
+		if (signer == "SMART_ID") {
 			// "https://sid.demo.sk.ee/smart-id-rp/v2"
 			std::string url = conf->getValue(Configuration::SID_DOMAIN, Configuration::BASE_URL);
 			// "00000000-0000-0000-0000-000000000000"
@@ -256,7 +258,7 @@ CDoc2Reader::getFMK(std::vector<uint8_t>& fmk, unsigned int lock_idx)
 			SIDSigner signer(url, relyingPartyUUID, relyingPartyName, rcpt_id, network);
 			result = signer.generateTickets(tickets, shares);
 			if (result == OK) cert = std::move(signer.cert);
-		} else if (conf->getValue(Configuration::SHARE_SIGNER) == "MOBILE_ID") {
+		} else if (signer == "MOBILE_ID") {
 			// "https://sid.demo.sk.ee/smart-id-rp/v2"
 			std::string url = conf->getValue(Configuration::MID_DOMAIN, Configuration::BASE_URL);
 			// "00000000-0000-0000-0000-000000000000"

--- a/cdoc/CDoc2Writer.cpp
+++ b/cdoc/CDoc2Writer.cpp
@@ -506,7 +506,7 @@ CDoc2Writer::buildHeader(std::vector<uint8_t>& header, const std::vector<libcdoc
             }
             std::vector<flatbuffers::Offset<cdoc20::recipients::KeyShare>> shares;
             for (int i = 0; i < N_SHARES; i++) {
-                auto share = cdoc20::recipients::CreateKeyShare(builder, builder.CreateString(urls[i]), builder.CreateString(std::string((const char *)transaction_ids[i].data(), transaction_ids[i].size())));
+                auto share = cdoc20::recipients::CreateKeyShare(builder, builder.CreateString(urls[i]), builder.CreateString((const char *)transaction_ids[i].data(), transaction_ids[i].size()));
                 shares.push_back(share);
             }
             auto fb_shares = builder.CreateVector(shares);

--- a/cdoc/KeyShares.cpp
+++ b/cdoc/KeyShares.cpp
@@ -67,6 +67,7 @@ struct JWTSigner {
     Signer *parent;
     JWTSigner(Signer *_parent) : parent(_parent) {}
     std::string sign(const std::string& data, std::error_code& ec) const {
+        LOG_DBG("Sign JWT: {}", data);
         std::vector<uint8_t> digest(32);
         SHA256((uint8_t *) data.c_str(), data.size(), digest.data());
         std::vector<uint8_t> dst;
@@ -114,7 +115,7 @@ Disclosure::Disclosure(const std::string name, const std::string& val)
 
 Disclosure::Disclosure(const std::string name, std::vector<Disclosure>& val)
 {
-    salt64 = toBase64URL(libcdoc::Crypto::random(18));
+    salt64 = toBase64URL(libcdoc::Crypto::random(16));
     //
     // [SALT, [{..., HASH}, {..., HASH}...]
     // [SALT, NAME, [{..., HASH}, {..., HASH}...]
@@ -125,7 +126,6 @@ Disclosure::Disclosure(const std::string name, std::vector<Disclosure>& val)
             {"...", picojson::value(d.getSHA256())}
         });
         l.push_back(picojson::value(o));
-        std::cerr << picojson::value(o).serialize() << std::endl;
     }
     std::vector<picojson::value> v;
     if (name.empty()) {
@@ -214,9 +214,9 @@ libcdoc::MIDSigner::signDigest(std::vector<uint8_t>& dst, const std::vector<uint
 
     network->signMID(dst, cert, url, rp_uuid, rp_name, phone, rcpt_id, digest, libcdoc::CryptoBackend::SHA_256);
 
-    LOG_DBG("SID dignature:{}", toHex(dst));
-    LOG_DBG("SID signatureB64:{}", toBase64URL(dst));
-    LOG_DBG("SID certificateB64:{}", toBase64(cert));
+    LOG_DBG("MID signature:{}", toHex(dst));
+    LOG_DBG("MID signatureB64:{}", toBase64URL(dst));
+    LOG_DBG("MID certificateB64:{}", toBase64(cert));
     
     return OK;
 }

--- a/cdoc/NetworkBackend.cpp
+++ b/cdoc/NetworkBackend.cpp
@@ -683,7 +683,7 @@ waitForResultMID(SIDResponse& dst, httplib::SSLClient& cli, const std::string& p
             return UNSPECIFIED_ERROR;
         }
         // State is complete, check for end result
-        picojson::value w = v.get("result");
+        picojson::value w = rsp.get("result");
         if (!w.is<std::string>()) {
             LOG_WARN("result is not a string");
             return UNSPECIFIED_ERROR;
@@ -712,7 +712,7 @@ waitForResultMID(SIDResponse& dst, httplib::SSLClient& cli, const std::string& p
             dst.algorithm = w.get<std::string>();
         }
         // Certificate
-        w = v.get("cert");
+        w = rsp.get("cert");
         if (!w.is<std::string>()) {
             LOG_WARN("cert is not a string");
             return UNSPECIFIED_ERROR;

--- a/cdoc/ToolConf.h
+++ b/cdoc/ToolConf.h
@@ -76,7 +76,6 @@ struct ToolConf : public JSONConfiguration {
      * @brief The list of accepted keyserver certificates (empty - accept all)
      */
     std::vector<std::vector<uint8_t>> accept_certs;
-    std::map<std::string,std::vector<uint8_t>> server_certs;
 
     std::string getValue(std::string_view domain, std::string_view param) const final {
         for (auto& sdata : servers) {

--- a/cdoc/ToolConf.h
+++ b/cdoc/ToolConf.h
@@ -76,6 +76,7 @@ struct ToolConf : public JSONConfiguration {
      * @brief The list of accepted keyserver certificates (empty - accept all)
      */
     std::vector<std::vector<uint8_t>> accept_certs;
+    std::map<std::string,std::vector<uint8_t>> server_certs;
 
     std::string getValue(std::string_view domain, std::string_view param) const final {
         for (auto& sdata : servers) {

--- a/cdoc/Utils.cpp
+++ b/cdoc/Utils.cpp
@@ -20,6 +20,7 @@
 
 #include "ILogger.h"
 
+#include "json/jwt.h"
 #include "json/picojson/picojson.h"
 
 #define OPENSSL_SUPPRESS_DEPRECATED
@@ -44,11 +45,8 @@ toBase64(const uint8_t *data, size_t len)
 std::vector<uint8_t>
 fromBase64(const std::string& data)
 {
-    std::vector<uint8_t> input(data.cbegin(), data.cend());
-    std::vector<uint8_t> result(input.size() / 4 * 3, 0);
-    int size = EVP_DecodeBlock(result.data(), input.data(), static_cast<int>(input.size()));
-    result.resize(size);
-    return result;
+    std::string str = jwt::base::details::decode(data, jwt::alphabet::base64::rdata(), "=");
+    return std::vector<uint8_t>(str.cbegin(), str.cend());
 }
 
 double

--- a/cdoc/WinBackend.h
+++ b/cdoc/WinBackend.h
@@ -33,6 +33,14 @@ namespace libcdoc {
  * then call useKey to load the key.
  */
 struct CDOC_EXPORT WinBackend : public CryptoBackend {
+    /**
+     * @brief Load the actual private key
+     * 
+     * Loads the key internally for subsequent cryptographic operations.
+     * @param name the name of key
+     * @param pin key pin
+     * @return result_t error code ot OK
+     */
     result_t useKey(const std::string& name, const std::string& pin);
 
     /**


### PR DESCRIPTION
Small fixes, the most important being fromBase64() length issue.
This makes signing with Mobile ID working for key shares.

Signed-off-by: Lauris Kaplinski <lauris@raulwalter.com>
